### PR TITLE
lazy server connect; setremotes command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Requirements:
 * UNIX-like system with `SO_REUSEPORT | SO_REUSEADDR` support
 * `epoll` support
 * pthread
-* C++ compiler & lib with C++11 features, like g++ 4.8 or clang++ 3.2
+* C++ compiler & lib with C++11 features, like g++ 4.8 or clang++ 3.2 (NOTE: install clang++ 3.2 on CentOS 6.5 won't compile because clang uses header files from gcc, which is version 4.4 without C++11 support)
 * Google Test (for test)
 
 To build, just
@@ -61,9 +61,10 @@ Restricted Commands Bypass
 Extra Commands
 ---
 
-* `PROXY`: shows proxy information, including threads count, clients counts
+* `PROXY` / `INFO`: shows proxy information, including threads count, clients counts, commands statistics
 * `KEYSINSLOT slot count`: list keys in a specified slot, same as `CLUSTER GETKEYSINSLOT slot count`
 * `UPDATESLOTMAP`: notify each thread to update slot map after the next operation
+* `SETREMOTES host port host port ...`: reset redis server addresses to arguments, and update slot map after that
 
 Not Implemented
 ---
@@ -79,7 +80,7 @@ others: `PFADD`, `PFCOUNT`, `PFMERGE`,
 `WATCH`, `UNWATCH`, `EXEC`, `DISCARD`, `MULTI`,
 `SELECT`, `QUIT`, `ECHO`, `AUTH`,
 `CLUSTER`, `BGREWRITEAOF`, `BGSAVE`, `CLIENT`, `COMMAND`, `CONFIG`,
-`DBSIZE`, `DEBUG`, `FLUSHALL`, `FLUSHDB`, `INFO`, `LASTSAVE`, `MONITOR`,
+`DBSIZE`, `DEBUG`, `FLUSHALL`, `FLUSHDB`, `LASTSAVE`, `MONITOR`,
 `ROLE`, `SAVE`, `SHUTDOWN`, `SLAVEOF`, `SLOWLOG`, `SYNC`, `TIME`,
 
 For more information please read [here (CN)](https://github.com/HunanTV/redis-cerberus/wiki/Redis-%E9%9B%86%E7%BE%A4%E4%BB%A3%E7%90%86%E5%9F%BA%E6%9C%AC%E5%8E%9F%E7%90%86%E4%B8%8E%E4%BD%BF%E7%94%A8).

--- a/common.hpp
+++ b/common.hpp
@@ -5,7 +5,7 @@
 
 #include "utils/typetraits.hpp"
 
-#define VERSION "0.6.4-2015-04-30"
+#define VERSION "0.6.5-2015-05-25"
 
 namespace cerb {
 

--- a/core/exceptions.hpp
+++ b/core/exceptions.hpp
@@ -15,15 +15,6 @@ namespace cerb {
         explicit BadRedisMessage(std::string const& what);
     };
 
-    class BadClusterStatus
-        : public std::runtime_error
-    {
-    public:
-        explicit BadClusterStatus(std::string const& what)
-            : std::runtime_error(what)
-        {}
-    };
-
     class SystemError
         : public std::runtime_error
     {

--- a/core/proxy.hpp
+++ b/core/proxy.hpp
@@ -1,6 +1,7 @@
 #ifndef __CERBERUS_PROXY_HPP__
 #define __CERBERUS_PROXY_HPP__
 
+#include <mutex>
 #include <vector>
 
 #include "utils/pointer.h"
@@ -60,6 +61,8 @@ namespace cerb {
         int _clients_count;
 
         SlotMap _server_map;
+        std::set<util::Address> _candidate_addrs;
+        std::mutex _candidate_addrs_mutex;
         std::vector<util::sptr<SlotsMapUpdater>> _slot_updaters;
         std::vector<util::sptr<SlotsMapUpdater>> _finished_slot_updaters;
         int _active_slot_updaters_count;
@@ -74,7 +77,9 @@ namespace cerb {
 
         bool _should_update_slot_map() const;
         void _retrieve_slot_map();
+        void _close_servers(std::set<Server*> servers);
         void _set_slot_map(std::vector<RedisNode> map);
+        void _update_slot_map_failed(std::set<util::Address> addrs);
         void _update_slot_map();
         void _loop();
     public:
@@ -123,6 +128,7 @@ namespace cerb {
         Server* get_server_by_slot(slot key_slot);
         void notify_slot_map_updated();
         void update_slot_map();
+        void update_remotes(std::set<util::Address> remotes);
         void retry_move_ask_command_later(util::sref<DataCommand> cmd);
         void run(int listen_port);
         void accept_from(int listen_fd);

--- a/core/slot_map.hpp
+++ b/core/slot_map.hpp
@@ -81,6 +81,7 @@ namespace cerb {
         }
 
         std::set<Server*> replace_map(std::vector<RedisNode> const& nodes, Proxy* proxy);
+        std::set<Server*> deliver();
         Server* random_addr() const;
 
         static void select_slave_if_possible();

--- a/test/slot_map.cpp
+++ b/test/slot_map.cpp
@@ -389,3 +389,16 @@ TEST(SlotMap, ReplaceNodesAlsoSlave)
         ASSERT_EQ(7000, svr->addr.port) << " slot #" << s;
     }
 }
+
+TEST(SlotMap, NonsenseProof)
+{
+    cerb::SlotMap slot_map;
+    std::set<cerb::Server*> replaced = slot_map.replace_map(cerb::parse_slot_map(
+        "The quick brown fox jumps over a lazy dog.",
+        "127.0.0.1"), nullptr);
+    ASSERT_TRUE(replaced.empty());
+    replaced = slot_map.replace_map(cerb::parse_slot_map(
+        "6c001456aff0ae537ba242d4e86fb325c5babbea 192.168.1.100:7000 myself,master - 0 0 1 connected abc",
+        "127.0.0.1"), nullptr);
+    ASSERT_TRUE(replaced.empty());
+}


### PR DESCRIPTION
此版本更新延迟连接特性, 以及 `setremotes` 命令.

在 redis 集群没有启动或者集群挂掉的情况下, 向 cerberus 发送指令不再会导致 cerberus 退出, 而是返回一条 `-CLUSTERDOWN` 错误. 集群恢复后, 一般来说 cerberus 会自动重新连接 redis. 如果 redis 的地址全部改变了, 可以使用 `setremotes` 命令强制 cerberus 去连接指定的节点来重新工作.

例如, cerberus 启动后再启动 3 个 redis 的集群, 3 个 redis 的地址分别是

    127.0.0.1:7000
    127.0.0.1:7001
    127.0.0.1:7002

那么使用 redis-cli 连接到 cerberus, 然后执行

    setremotes 127.0.0.1:7000

即可.