### PR TITLE
Fix:When remotes fail, SlotsMapUpdater may close server before it reads

### DIFF
--- a/common.hpp
+++ b/common.hpp
@@ -5,7 +5,7 @@
 
 #include "utils/typetraits.hpp"
 
-#define VERSION "0.6.11-2015-08-05"
+#define VERSION "0.6.12-2015-08-06"
 
 namespace cerb {
 

--- a/core/proxy.hpp
+++ b/core/proxy.hpp
@@ -55,6 +55,7 @@ namespace cerb {
         void _set_slot_map(std::vector<RedisNode> map, std::set<util::Address> remotes);
         void _update_slot_map_failed();
         void _update_slot_map();
+        void _move_closed_slot_updaters();
     public:
         int epfd;
 

--- a/core/server.cpp
+++ b/core/server.cpp
@@ -16,6 +16,9 @@ using namespace cerb;
 
 void Server::on_events(int events)
 {
+    if (this->closed()) {
+        return;
+    }
     if (poll::event_is_hup(events)) {
         return this->close_conn();
     }
@@ -72,7 +75,6 @@ void Server::_recv_from()
 {
     int n = this->_buffer.read(this->fd);
     if (n == 0) {
-        LOG(INFO) << "Server hang up: " << this->str();
         throw ConnectionHungUp();
     }
     LOG(DEBUG) << "Read " << this->str() << " buffer size " << this->_buffer.size();
@@ -222,7 +224,13 @@ Server* Server::_alloc_server(util::Address const& addr, Proxy* p)
         }
     }
     Server* s = servers_pool.back();
-    s->_reconnect(addr, p);
+    try {
+        s->_reconnect(addr, p);
+    } catch (IOErrorBase& e) {
+        LOG(ERROR) << "Fail to open server " << s->str() << " because " << e.what();
+        s->close_conn();
+        return s;
+    }
     servers_pool.pop_back();
     return s;
 }

--- a/test/Makefile
+++ b/test/Makefile
@@ -59,14 +59,15 @@ server-client-test:server-client.dt mock-proxy.dt mock-suit
 	$(VALGRIND) $(TESTDIR)/test-server-client.out
 
 event-loop-test:event-loop-test.dt mock-suit event-loop-data-proxy.dt \
-                event-loop-long-conn.dt
-	$(LINK) $(TESTDIR)/event-loop-test.o $(TESTDIR)/event-loop-data-proxy.o \
-	     $(TESTDIR)/event-loop-long-conn.o utils/*.o $(MOCK_OBJS) \
+                event-loop-long-conn.dt event-loop-slot-map-updating.dt
+	$(LINK) $(TESTDIR)/event-loop-test.o utils/*.o $(MOCK_OBJS) \
 	     $(OBJDIR)/connection.o $(OBJDIR)/server.o $(OBJDIR)/client.o \
 	     $(OBJDIR)/fdutil.o $(OBJDIR)/response.o $(OBJDIR)/command.o \
 	     $(OBJDIR)/subscription.o $(OBJDIR)/message.o $(OBJDIR)/globals.o \
 	     $(OBJDIR)/buffer.o $(OBJDIR)/slot_calc.o $(OBJDIR)/slot_map.o \
-	     $(OBJDIR)/proxy.o $(TEST_LIBS) \
+	     $(OBJDIR)/proxy.o $(TEST_LIBS) $(TESTDIR)/event-loop-data-proxy.o \
+	     $(TESTDIR)/event-loop-long-conn.o \
+	     $(TESTDIR)/event-loop-slot-map-updating.o \
 	  -o $(TESTDIR)/test-event-loop.out
 	$(VALGRIND) $(TESTDIR)/test-event-loop.out
 

--- a/test/event-loop-data-proxy.cpp
+++ b/test/event-loop-data-proxy.cpp
@@ -1,4 +1,3 @@
-#include "utils/string.h"
 #include "core/server.hpp"
 #include "core/message.hpp"
 #include "core/globals.hpp"

--- a/test/event-loop-slot-map-updating.cpp
+++ b/test/event-loop-slot-map-updating.cpp
@@ -1,0 +1,74 @@
+#include "utils/string.h"
+#include "core/server.hpp"
+#include "core/message.hpp"
+#include "core/globals.hpp"
+#include "event-loop-test.hpp"
+
+using namespace cerb;
+using cerb::msg::format_command;
+
+typedef EventLoopTest EventLoopSlotMapUpdatingTest;
+
+TEST_F(EventLoopSlotMapUpdatingTest, ServerReadAfterUpdateFailed)
+{
+    std::vector<RedisNode> nodes;
+    RedisNode x(util::Address("10.0.0.1", 9001), "391a908a30eb413929229fa34bf473c742c91cef");
+    x.slot_ranges.insert(std::make_pair(0, 0));
+    RedisNode y(util::Address("10.0.0.1", 9000), "491a908a30eb413929229fa34bf473c742c91cd0");
+    y.slot_ranges.insert(std::make_pair(1, 16383));
+    nodes.push_back(std::move(x));
+    nodes.push_back(std::move(y));
+    EventLoopTest::proxy->notify_slot_map_updated(std::move(nodes));
+
+    Server* server_a = EventLoopTest::proxy->get_server_by_slot(0);
+    Server* server_b = EventLoopTest::proxy->get_server_by_slot(1);
+    ASSERT_NE(nullptr, server_a);
+    ASSERT_NE(nullptr, server_b);
+    ASSERT_FALSE(server_a->closed());
+    ASSERT_FALSE(server_b->closed());
+    ASSERT_NE(server_a->fd, server_b->fd);
+
+    int client = EventLoopTest::connect_client();
+    EventLoopTest::push_read_of(client, format_command("INFO", {}));
+    EventLoopTest::run_all_polls();
+
+    /* a not in slot #0 */
+    EventLoopTest::push_read_of(client, format_command("GET", {"a"}));
+    int nfd = EventLoopTest::run_poll();
+    ASSERT_EQ(1, nfd);
+    ASSERT_EQ(std::set<int>({client}), EventLoopTest::last_pollees());
+    nfd = EventLoopTest::run_poll();
+    ASSERT_EQ(1, nfd);
+    ASSERT_EQ(std::set<int>({server_b->fd}), EventLoopTest::last_pollees());
+
+    EventLoopTest::reset_conn(server_a->fd);
+    EventLoopTest::run_all_polls();
+
+    int updater = EventLoopTest::last_fd();
+    /* some slots not covered */
+    std::set<int> updaters;
+    for (int u = client + 1; u <= updater; ++u) {
+        updaters.insert(u);
+        EventLoopTest::push_read_of(
+            u,
+            "+391a908a30eb413929229fa34bf473c742c91cef 10.0.0.1:9000"
+            " master - 0 0 0 connected 1-16383\n"
+             "491a908a30eb413929229fa34bf473c742c91cd0 10.0.0.1:9001"
+            " master - 0 0 0 connected"
+            "\r\n");
+    }
+    EventLoopTest::push_read_of(server_b->fd, "$1\r\nb\r\n");
+    std::set<int> fds(updaters);
+    fds.insert(server_b->fd);
+    poll::pevent events[poll::MAX_EVENTS];
+    nfd = EventLoopTest::poll_obj->poll_wait(events, poll::MAX_EVENTS);
+    ASSERT_EQ(fds, EventLoopTest::last_pollees());
+    /* shift server_b to the last, so updaters close all servers before it reads */
+    for (int i = 0; i < nfd - 1; ++i) {
+        if (events[i].data.ptr == server_b) {
+            std::swap(events[i].events, events[nfd - 1].events);
+            std::swap(events[i].data.ptr, events[nfd - 1].data.ptr);
+        }
+    }
+    EventLoopTest::proxy->handle_events(events, nfd);
+}

--- a/test/event-loop-test.cpp
+++ b/test/event-loop-test.cpp
@@ -31,8 +31,9 @@ void AutomaticPoller::poll_del(int, int evtfd)
     registered_data.erase(evtfd);
 }
 
-int AutomaticPoller::poll_wait(poll::pevent* events, int maxevents)
+int AutomaticPoller::poll_wait(poll::pevent events[], int maxevents)
 {
+    this->last_pollees.clear();
     int count = 0;
     for (auto i: this->pollees) {
         int flags = 0;
@@ -43,6 +44,7 @@ int AutomaticPoller::poll_wait(poll::pevent* events, int maxevents)
             flags |= EV_READ;
         }
         if (flags != 0) {
+            this->last_pollees.insert(i.first);
             events[count].events = flags;
             events[count].data.ptr = this->registered_data[i.first];
             ++count;


### PR DESCRIPTION
崩溃原因描述

* 在一个主节点挂掉后, 在主从替换之前, 有一小段时间, 集群会处在失效状态 (不是所有的槽位都可用)
* 此时, 如果所有 `SlotsMapUpdater` 都请求到这一失效的槽位映射表, 会认为集群失效, 并关闭所有远端连接, 将代理重置为 CLUSTERDOWN 状态
* 若在一次事件循环中, 所有 `SlotsMapUpdater` 对象在前, 请求到了失效的映射表并关闭了所有远端连接; 而之后有 `Server` 对象, 那么对该 `Server` 的操作会产生一个 Bad file descriptor 错误

测试覆盖

* 添加测试 `EventLoopSlotMapUpdatingTest::ServerReadAfterUpdateFailed`, 在一次事件循环中将 `Server` 手动调整到靠后的位置, 可以触发此问题

解决方案

* 若 `Server` 对象已经关闭, 则 `Server::on_events` 直接退出