### PR TITLE
select slave

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Build
 
 Requirements:
 
+* `make` and `cmake`
 * UNIX-like system with `SO_REUSEPORT | SO_REUSEADDR` support
 * `epoll` support
 * pthread
@@ -45,7 +46,8 @@ The first argument is path of a configuration file, then optional arguments. Tho
 * bind / `-b` : (integer) local port to listen; could also specified
 * node / `-n` : (address, optional) one of active node in a cluster; format should be *host:port*; could also set after cerberus launched, via the `SETREMOTES` command, see it below
 * thread / `-t` : (integer) number of threads
-* read-slave / `r` : (optional, default off) set to "1" to turn on read slave mode. A proxy in read-slave mode won't support writing commands like `SET`, `INCR`, `PUBLISH`, and it would select slave nodes for reading commands if possible.  For more information please read [here (CN)](https://github.com/HunanTV/redis-cerberus/wiki/%E8%AF%BB%E5%86%99%E5%88%86%E7%A6%BB).
+* read-slave / `-r` : (optional, default off) set to "1" to turn on read slave mode. A proxy in read-slave mode won't support writing commands like `SET`, `INCR`, `PUBLISH`, and it would select slave nodes for reading commands if possible. For more information please read [here (CN)](https://github.com/HunanTV/redis-cerberus/wiki/%E8%AF%BB%E5%86%99%E5%88%86%E7%A6%BB).
+* read-slave-filter / `-R` : (optional, need read-slave set to 1) if multiple slaves replicating one master, use the one whose host starts with this option value; for example, you have `10.0.0.1:7000` as a master, with 2 slave `10.0.1.1:8000` and `10.0.2.1:9000`, and read-slave-filter set to `10.0.1`, then `10.0.1.1:8000` is preferred. Note this option is no more than a string matching, so `10.0.1.1` and `10.0.10.1` won't be different on option value `10.0.1`
 
 The option set via ARGS would override it in the configuration file. For example
 
@@ -63,7 +65,8 @@ Restricted Commands Bypass
 * `MSET` : execute multiple `SET`s
 * `DEL` : execute multiple `DEL`s
 * `RENAME` : if source and destination are not in the same slot, execute a `GET`-`SET`-`DEL` sequence without atomicity
-* `BLPOP` / `BRPOP`: one list limited; might return nil value before timeout [See detail (CN)](https://github.com/HunanTV/redis-cerberus/wiki/BLPOP-And-BRPOP)
+* `BLPOP` / `BRPOP` : one list limited; might return nil value before timeout [See detail (CN)](https://github.com/HunanTV/redis-cerberus/wiki/BLPOP-And-BRPOP)
+* `EVAL` : one key limited; if any key which is not in the same slot with the argument key is in the lua script, a cross slot error would return
 
 Extra Commands
 ---
@@ -83,7 +86,7 @@ Not Implemented
 * pub/sub: `PUBSUB`, `PUNSUBSCRIBE`, `UNSUBSCRIBE`,
 
 others: `PFADD`, `PFCOUNT`, `PFMERGE`,
-`EVAL`, `EVALSHA`, `SCRIPT`,
+`EVALSHA`, `SCRIPT`,
 `WATCH`, `UNWATCH`, `EXEC`, `DISCARD`, `MULTI`,
 `SELECT`, `QUIT`, `ECHO`, `AUTH`,
 `CLUSTER`, `BGREWRITEAOF`, `BGSAVE`, `CLIENT`, `COMMAND`, `CONFIG`,

--- a/common.hpp
+++ b/common.hpp
@@ -5,7 +5,7 @@
 
 #include "utils/typetraits.hpp"
 
-#define VERSION "0.6.13-2015-08-13"
+#define VERSION "0.7.0-2015-08-25"
 
 namespace cerb {
 

--- a/core/command.cpp
+++ b/core/command.cpp
@@ -760,7 +760,7 @@ namespace {
         void on_byte(byte) {}
         void on_element(Buffer::iterator)
         {
-            no_arg = false;
+            this->no_arg = false;
         }
 
         explicit SubscribeCommandParser(Buffer::iterator begin)
@@ -771,7 +771,7 @@ namespace {
         util::sptr<CommandGroup> spawn_commands(
             util::sref<Client> c, Buffer::iterator end)
         {
-            if (no_arg) {
+            if (this->no_arg) {
                 return util::mkptr(new DirectCommandGroup(
                     c, "-ERR wrong number of arguments for 'subscribe' command\r\n"));
             }
@@ -800,7 +800,7 @@ namespace {
                 if (s == nullptr) {
                     return this->client->close();
                 }
-                new BlockedListPop(p, this->client->fd, s, std::move(buffer));
+                new BlockedListPop(p, this->client->fd, s, std::move(this->buffer));
                 LOG(DEBUG) << "Convert " << this->client->str() << " as blocked pop";
                 this->client->fd = -1;
             }
@@ -919,7 +919,7 @@ namespace {
         void on_byte(byte) {}
         void on_element(Buffer::iterator)
         {
-            ++arg_count;
+            ++this->arg_count;
         }
 
         explicit PublishCommandParser(Buffer::iterator begin)
@@ -930,12 +930,12 @@ namespace {
         util::sptr<CommandGroup> spawn_commands(
             util::sref<Client> c, Buffer::iterator end)
         {
-            if (arg_count != 2) {
+            if (this->arg_count != 2) {
                 return util::mkptr(new DirectCommandGroup(
                     c, "-ERR wrong number of arguments for 'publish' command\r\n"));
             }
             return util::mkptr(new SingleCommandGroup(
-                c, Buffer(begin, end), util::randint(0, CLUSTER_SLOT_COUNT)));
+                c, Buffer(this->begin, end), util::randint(0, CLUSTER_SLOT_COUNT)));
         }
     };
 
@@ -983,13 +983,13 @@ namespace {
         util::sptr<CommandGroup> spawn_commands(
             util::sref<Client> c, Buffer::iterator end)
         {
-            if (_arg_count != 2 || _error || _slot >= CLUSTER_SLOT_COUNT) {
+            if (this->_arg_count != 2 || this->_error || this->_slot >= CLUSTER_SLOT_COUNT) {
                 return util::mkptr(new DirectCommandGroup(
                     c, "-ERR wrong arguments for 'keysinslot' command\r\n"));
             }
             Buffer buffer(Buffer::from_string("*4\r\n$7\r\nCLUSTER\r\n$13\r\nGETKEYSINSLOT\r\n"));
-            buffer.append_from(_arg_start, end);
-            return util::mkptr(new SingleCommandGroup(c, std::move(buffer), _slot));
+            buffer.append_from(this->_arg_start, end);
+            return util::mkptr(new SingleCommandGroup(c, std::move(buffer), this->_slot));
         }
     };
 

--- a/core/slot_map.hpp
+++ b/core/slot_map.hpp
@@ -84,7 +84,7 @@ namespace cerb {
         void clear();
         Server* random_addr() const;
 
-        static void select_slave_if_possible();
+        static void select_slave_if_possible(std::string host_beginning);
     };
 
     std::vector<RedisNode> parse_slot_map(std::string const& nodes_info,

--- a/example.conf
+++ b/example.conf
@@ -2,3 +2,4 @@ bind 8889
 node 127.0.0.1:7000
 thread 4
 read-slave 0
+read-slave-filter 10.0.1

--- a/main.cpp
+++ b/main.cpp
@@ -23,7 +23,7 @@ namespace {
         {
             int ch;
             opterr = 0;
-            while ((ch = getopt(argc, argv, "b:n:t:r:")) != EOF) {
+            while ((ch = getopt(argc, argv, "b:n:t:r:R:")) != EOF) {
                 switch (ch) {
                 case 'b':
                     _config["bind"] = optarg;
@@ -36,6 +36,9 @@ namespace {
                     break;
                 case 'r':
                     _config["read-slave"] = optarg;
+                    break;
+                case 'R':
+                    _config["read-slave-filter"] = optarg;
                     break;
                 default:
                     std::cerr << "Invalid option." << std::endl;
@@ -103,7 +106,7 @@ namespace {
             LOG(INFO) << "Readonly proxy, use slaves for reading if possible";
             cerb::Server::send_readonly_for_each_conn();
             cerb::stats_set_read_slave();
-            cerb::SlotMap::select_slave_if_possible();
+            cerb::SlotMap::select_slave_if_possible(config.get("read-slave-filter", ""));
         } else {
             LOG(INFO) << "Writable proxy";
             cerb::Command::allow_write_commands();
@@ -151,6 +154,9 @@ int main(int argc, char* argv[])
         std::cerr << "    -t THREAD : thread count" << std::endl;
         std::cerr << "    -r READONLY : if the proxy is readonly,"
                            " value shall be 0 or 1 for false or true" << std::endl;
+        std::cerr << "    -R SLAVE_HOST_BEGINING : (if READONLY set to 1)"
+                           " if multiple slaves replicating one master,"
+                           " use the one whose host starts with this pattern" << std::endl;
         std::cerr << "  Options passed by command line will override"
                          " those in the config file" << std::endl;
         return 1;

--- a/test/slot_map.cpp
+++ b/test/slot_map.cpp
@@ -315,7 +315,7 @@ TEST_F(SlotMapTest, ReplaceNodesAllMasters)
 
 TEST_F(SlotMapTest, ReplaceNodesAlsoSlave)
 {
-    cerb::SlotMap::select_slave_if_possible();
+    cerb::SlotMap::select_slave_if_possible("");
     cerb::SlotMap slot_map;
 
     slot_map.replace_map(cerb::parse_slot_map(


### PR DESCRIPTION
so, 其实感觉有点解决别的公司不存在的问题...
我厂有两个机房, 一个机房的内网 IP 比如是 `10.10.x.x`, 另一个是 `10.11.x.x`
某个项目在两个机房都部署, 需要访问各自机房的 redis (只读, 写请求不多) 以减少读请求延迟
于是, 需要在各机房分别建立一组从节点, 然后要求 cerberus 连自己所在的机房里的从节点, 因此就有了这么一个功能 (以及选项)