### PR TITLE
[WIP] Fix mem

### DIFF
--- a/common.hpp
+++ b/common.hpp
@@ -5,7 +5,7 @@
 
 #include "utils/typetraits.hpp"
 
-#define VERSION "0.7.2-2015-09-18"
+#define VERSION "0.7.3-2015-10-08"
 
 namespace cerb {
 

--- a/core/client.cpp
+++ b/core/client.cpp
@@ -96,7 +96,7 @@ void Client::_write_response()
         return;
     }
 
-    this->_ready_groups = std::move(this->_awaiting_groups);
+    this->_ready_groups.swap(this->_awaiting_groups);
     for (auto const& g: this->_ready_groups) {
         g->append_buffer_to(this->_output_buffer_set);
     }

--- a/core/client.cpp
+++ b/core/client.cpp
@@ -10,6 +10,8 @@
 
 using namespace cerb;
 
+static msize_t const MAX_PIPE = 64;
+
 Client::Client(int fd, Proxy* p)
     : ProxyConnection(fd)
     , _proxy(p)
@@ -42,10 +44,8 @@ void Client::on_events(int events)
             this->_write_response();
         }
     } catch (BadRedisMessage& e) {
-        LOG(DEBUG) << "Receive bad message from " << this->str()
-                   << " because: " << e.what()
-                   << "\nDump buffer (before close): "
-                   << this->_buffer.to_string();
+        LOG(INFO) << fmt::format("Receive bad message from {} because {}", this->str(), e.what());
+        LOG(DEBUG) << "Dump buffer " << this->_buffer.to_string();
         return this->close();
     } catch (IOErrorBase& e) {
         LOG(DEBUG) << "IOError: " << e.what() << " :: Close " << this->str();
@@ -131,11 +131,14 @@ void Client::reactivate(util::sref<Command> cmd)
 
 void Client::_process()
 {
-    for (auto& g: this->_parsed_groups) {
+    msize_t pipe_groups = std::min(msize_t(this->_parsed_groups.size()), MAX_PIPE);
+    LOG(DEBUG) << fmt::format("{} Process {} over {} commands", this->str(), pipe_groups, this->_parsed_groups.size());
+    for (msize_t i = 0; i < pipe_groups; ++i) {
+        auto& g = this->_parsed_groups[i];
         if (g->long_connection()) {
             this->_proxy->poll_del(this);
             g->deliver_client(this->_proxy);
-            LOG(DEBUG) << "Convert self to long connection, delete " << this;
+            LOG(DEBUG) << "Convert self to long connection, close " << this->str();
             return this->close();
         }
 
@@ -145,7 +148,12 @@ void Client::_process()
         }
         this->_awaiting_groups.push_back(std::move(g));
     }
-    this->_parsed_groups.clear();
+    if (pipe_groups == this->_parsed_groups.size()) {
+        this->_parsed_groups.clear();
+    } else {
+        this->_parsed_groups.erase(this->_parsed_groups.begin(),
+                                   this->_parsed_groups.begin() + pipe_groups);
+    }
 
     if (0 < this->_awaiting_count) {
         for (Server* svr: this->_peers) {

--- a/core/command.cpp
+++ b/core/command.cpp
@@ -1209,7 +1209,7 @@ namespace {
             /*
              * Redis server will reset a request of more than 1M args.
              * See also
-             * https://github.com/antirez/redis/blob/3.0/src/networking.c#L1014
+             * https://github.com/antirez/redis/blob/3.0/src/networking.c#L1001
              */
             if (size > 1024 * 1024) {
                 throw BadRedisMessage("Request is too large");

--- a/core/command.hpp
+++ b/core/command.hpp
@@ -16,7 +16,7 @@ namespace cerb {
 
     class Command {
     public:
-        Buffer buffer;
+        std::shared_ptr<Buffer> buffer;
         util::sref<CommandGroup> const group;
 
         virtual ~Command() = default;
@@ -27,12 +27,13 @@ namespace cerb {
         void responsed();
 
         Command(Buffer b, util::sref<CommandGroup> g)
-            : buffer(std::move(b))
+            : buffer(new Buffer(std::move(b)))
             , group(g)
         {}
 
         explicit Command(util::sref<CommandGroup> g)
-            : group(g)
+            : buffer(new Buffer)
+            , group(g)
         {}
 
         Command(Command const&) = delete;

--- a/core/proxy.cpp
+++ b/core/proxy.cpp
@@ -182,7 +182,7 @@ void Proxy::_update_slot_map_failed()
     _server_map.clear();
     std::vector<util::sref<DataCommand>> cmds(std::move(this->_retrying_commands));
     for (util::sref<DataCommand> c: cmds) {
-        c->on_remote_responsed(Buffer::from_string("-CLUSTERDOWN The cluster is down\r\n"), true);
+        c->on_remote_responsed(Buffer("-CLUSTERDOWN The cluster is down\r\n"), true);
     }
     _slot_map_expired = false;
 }

--- a/core/response.cpp
+++ b/core/response.cpp
@@ -8,7 +8,8 @@
 
 using namespace cerb;
 
-Buffer const Response::NIL(Buffer::from_string("$-1\r\n"));
+std::string const Response::NIL_STR("$-1\r\n");
+Buffer const Response::NIL(NIL_STR);
 
 namespace {
 
@@ -55,8 +56,7 @@ namespace {
             return true;
         }
     };
-    Buffer const RetryMovedAskResponse::dump(
-        Buffer::from_string("$ RETRY MOVED OR ASK $"));
+    Buffer const RetryMovedAskResponse::dump("$ RETRY MOVED OR ASK $");
 
     class ServerResponseSplitter
         : public cerb::msg::MessageSplitterBase<

--- a/core/response.hpp
+++ b/core/response.hpp
@@ -21,6 +21,7 @@ namespace cerb {
         virtual Buffer const& get_buffer() const = 0;
         virtual bool server_moved() const { return false; }
 
+        static std::string const NIL_STR;
         static Buffer const NIL;
     };
 

--- a/core/server.cpp
+++ b/core/server.cpp
@@ -60,7 +60,7 @@ void Server::_send_to()
         return;
     }
 
-    this->_ready_commands = std::move(this->_commands);
+    this->_ready_commands.swap(this->_commands);
     for (util::sref<DataCommand> c: this->_ready_commands) {
         this->_output_buffer_set.append(util::mkref(c->buffer));
     }

--- a/core/server.hpp
+++ b/core/server.hpp
@@ -25,10 +25,9 @@ namespace cerb {
         std::vector<util::sref<DataCommand>> _commands;
         std::vector<util::sref<DataCommand>> _ready_commands;
 
-        void _send_to();
         void _recv_from();
         void _reconnect(util::Address const& addr, Proxy* p);
-        void _send_buffer_set();
+        void _push_to_buffer_set();
 
         Server()
             : ProxyConnection(-1)

--- a/core/slot_map.cpp
+++ b/core/slot_map.cpp
@@ -134,11 +134,11 @@ std::vector<RedisNode> cerb::parse_slot_map(std::string const& nodes_info,
     return std::move(slot_map);
 }
 
-static cerb::Buffer const CLUSTER_NODES_CMD(Buffer::from_string("*2\r\n$7\r\ncluster\r\n$5\r\nnodes\r\n"));
+static std::string const CLUSTER_NODES_CMD("*2\r\n$7\r\ncluster\r\n$5\r\nnodes\r\n");
 
 void cerb::write_slot_map_cmd_to(int fd)
 {
-    CLUSTER_NODES_CMD.write(fd);
+    flush_string(fd, CLUSTER_NODES_CMD);
 }
 
 void SlotMap::select_slave_if_possible(std::string host_beginning)

--- a/test/Makefile
+++ b/test/Makefile
@@ -13,7 +13,7 @@ endif
 MOCK_OBJS=$(TESTDIR)/mock-stats.o $(TESTDIR)/mock-io.o $(TESTDIR)/mock-poll.o \
           $(TESTDIR)/mock-acceptor.o
 
-test:core-objs util-test buffer-test slot-map-test server-client-test \
+test:core-objs buffer-test util-test slot-map-test server-client-test \
      event-loop-test script-test
 	@echo "======================"
 	@echo "| Test done _(:3J<)_ |"
@@ -24,6 +24,13 @@ core-objs:
 	@make -f core/Makefile OBJDIR=$(OBJDIR) MODE=$(MODE) \
 	    COMPILER=$(COMPILER) CANDIDATE_IO=1 CANDIDATE_POLL=1 CANDIDATE_FCTL=1
 
+buffer-test:buffer.dt mock-suit mock-server.dt mock-proxy.dt
+	$(LINK) $(TESTDIR)/buffer.o $(OBJDIR)/buffer.o $(OBJDIR)/connection.o \
+	        $(OBJDIR)/fdutil.o $(OBJDIR)/slot_map.o $(TESTDIR)/mock-proxy.o \
+	        utils/*.o $(TESTDIR)/mock-server.o $(MOCK_OBJS) $(TEST_LIBS) \
+	    -o $(TESTDIR)/test-buffer.out
+	$(VALGRIND) $(TESTDIR)/test-buffer.out
+
 util-test:message.dt response.dt buffer.dt slot_calc.dt mock-io.dt mock-suit \
           mock-server.dt mock-proxy.dt alg.dt
 	$(LINK) $(TESTDIR)/message.o $(TESTDIR)/response.o $(TESTDIR)/slot_calc.o \
@@ -33,13 +40,6 @@ util-test:message.dt response.dt buffer.dt slot_calc.dt mock-io.dt mock-suit \
 	        $(TESTDIR)/mock-server.o $(TESTDIR)/alg.o $(TEST_LIBS) \
 	     -o $(TESTDIR)/test-utils.out
 	$(VALGRIND) $(TESTDIR)/test-utils.out
-
-buffer-test:buffer.dt mock-suit mock-server.dt mock-proxy.dt
-	$(LINK) $(TESTDIR)/buffer.o $(OBJDIR)/buffer.o $(OBJDIR)/connection.o \
-	        $(OBJDIR)/fdutil.o $(OBJDIR)/slot_map.o $(TESTDIR)/mock-proxy.o \
-	        utils/*.o $(TESTDIR)/mock-server.o $(MOCK_OBJS) $(TEST_LIBS) \
-	     -o $(TESTDIR)/test-buffer.out
-	$(VALGRIND) $(TESTDIR)/test-buffer.out
 
 slot-map-test:slot_map.dt mock-server.dt mock-proxy.dt mock-suit
 	$(LINK) $(TESTDIR)/mock-server.o $(TESTDIR)/slot_map.o $(OBJDIR)/buffer.o \

--- a/test/buffer.cpp
+++ b/test/buffer.cpp
@@ -1,4 +1,5 @@
 #include "utils/string.h"
+#include "test-utils.hpp"
 #include "mock-io.hpp"
 #include "core/buffer.hpp"
 #include "core/fdutil.hpp"
@@ -9,9 +10,16 @@ typedef BufferTestBase BufferTest;
 
 TEST_F(BufferTest, AsString)
 {
-    Buffer buffer(Buffer::from_string("need a light"));
-    Buffer cuffer(Buffer::from_string("ghost reporting"));
+    Buffer buffer("need a light");
+    ASSERT_EQ(12, buffer.size());
+    ASSERT_EQ(std::string("need a light"), buffer.to_string());
+
+    Buffer cuffer("ghost reporting");
+    ASSERT_EQ(15, cuffer.size());
+    ASSERT_EQ(std::string("ghost reporting"), cuffer.to_string());
+
     buffer.append_from(cuffer.begin(), cuffer.end());
+    ASSERT_EQ(27, buffer.size());
     ASSERT_EQ(std::string("need a lightghost reporting"), buffer.to_string());
 }
 
@@ -34,25 +42,25 @@ TEST_F(BufferTest, IO)
 
 TEST_F(BufferTest, WriteVectorSimple)
 {
-    Buffer head(Buffer::from_string("0123456789abcdefghij"));
-    Buffer body(Buffer::from_string("QWEASDZXC+RTYFGHVBN-"));
-    Buffer tail(Buffer::from_string("!@#$%^&*()ABCDEFGHIJ"));
+    std::shared_ptr<Buffer> head(new Buffer("0123456789abcdefghij"));
+    std::shared_ptr<Buffer> body(new Buffer("QWEASDZXC+RTYFGHVBN-"));
+    std::shared_ptr<Buffer> tail(new Buffer("!@#$%^&*()ABCDEFGHIJ"));
 
     {
         BufferTest::io_obj->clear();
         BufferSet bufset;
-        bufset.append(util::mkref(head));
-        bufset.append(util::mkref(body));
-        bufset.append(util::mkref(tail));
+        bufset.append(head);
+        bufset.append(body);
+        bufset.append(tail);
 
         bool w = bufset.writev(0);
         ASSERT_TRUE(w);
         ASSERT_TRUE(bufset.empty());
 
         ASSERT_EQ(3, BufferTest::io_obj->write_buffer.size());
-        ASSERT_EQ(head.to_string(), BufferTest::io_obj->write_buffer[0]);
-        ASSERT_EQ(body.to_string(), BufferTest::io_obj->write_buffer[1]);
-        ASSERT_EQ(tail.to_string(), BufferTest::io_obj->write_buffer[2]);
+        ASSERT_EQ(head->to_string(), BufferTest::io_obj->write_buffer[0]);
+        ASSERT_EQ(body->to_string(), BufferTest::io_obj->write_buffer[1]);
+        ASSERT_EQ(tail->to_string(), BufferTest::io_obj->write_buffer[2]);
     }
 
     {
@@ -60,17 +68,17 @@ TEST_F(BufferTest, WriteVectorSimple)
         BufferTest::io_obj->writing_sizes.push_back(50);
 
         BufferSet bufset;
-        bufset.append(util::mkref(head));
-        bufset.append(util::mkref(body));
-        bufset.append(util::mkref(tail));
+        bufset.append(head);
+        bufset.append(body);
+        bufset.append(tail);
 
         bool w = bufset.writev(0);
         ASSERT_FALSE(w);
         ASSERT_FALSE(bufset.empty());
 
         ASSERT_EQ(3, BufferTest::io_obj->write_buffer.size());
-        ASSERT_EQ(head.to_string(), BufferTest::io_obj->write_buffer[0]);
-        ASSERT_EQ(body.to_string(), BufferTest::io_obj->write_buffer[1]);
+        ASSERT_EQ(head->to_string(), BufferTest::io_obj->write_buffer[0]);
+        ASSERT_EQ(body->to_string(), BufferTest::io_obj->write_buffer[1]);
         ASSERT_EQ("!@#$%^&*()", BufferTest::io_obj->write_buffer[2]);
 
         w = bufset.writev(0);
@@ -78,8 +86,8 @@ TEST_F(BufferTest, WriteVectorSimple)
         ASSERT_TRUE(bufset.empty());
 
         ASSERT_EQ(4, BufferTest::io_obj->write_buffer.size());
-        ASSERT_EQ(head.to_string(), BufferTest::io_obj->write_buffer[0]);
-        ASSERT_EQ(body.to_string(), BufferTest::io_obj->write_buffer[1]);
+        ASSERT_EQ(head->to_string(), BufferTest::io_obj->write_buffer[0]);
+        ASSERT_EQ(body->to_string(), BufferTest::io_obj->write_buffer[1]);
         ASSERT_EQ("!@#$%^&*()", BufferTest::io_obj->write_buffer[2]);
         ASSERT_EQ("ABCDEFGHIJ", BufferTest::io_obj->write_buffer[3]);
     }
@@ -90,16 +98,16 @@ TEST_F(BufferTest, WriteVectorSimple)
         BufferTest::io_obj->writing_sizes.push_back(17);
 
         BufferSet bufset;
-        bufset.append(util::mkref(head));
-        bufset.append(util::mkref(body));
-        bufset.append(util::mkref(tail));
+        bufset.append(head);
+        bufset.append(body);
+        bufset.append(tail);
 
         bool w = bufset.writev(0);
         ASSERT_FALSE(w);
         ASSERT_FALSE(bufset.empty());
 
         ASSERT_EQ(2, BufferTest::io_obj->write_buffer.size());
-        ASSERT_EQ(head.to_string(), BufferTest::io_obj->write_buffer[0]);
+        ASSERT_EQ(head->to_string(), BufferTest::io_obj->write_buffer[0]);
         ASSERT_EQ("QWEASDZXC+", BufferTest::io_obj->write_buffer[1]);
 
         w = bufset.writev(0);
@@ -107,7 +115,7 @@ TEST_F(BufferTest, WriteVectorSimple)
         ASSERT_FALSE(bufset.empty());
 
         ASSERT_EQ(4, BufferTest::io_obj->write_buffer.size());
-        ASSERT_EQ(head.to_string(), BufferTest::io_obj->write_buffer[0]);
+        ASSERT_EQ(head->to_string(), BufferTest::io_obj->write_buffer[0]);
         ASSERT_EQ("QWEASDZXC+", BufferTest::io_obj->write_buffer[1]);
         ASSERT_EQ("RTYFGHVBN-", BufferTest::io_obj->write_buffer[2]);
         ASSERT_EQ("!@#$%^&", BufferTest::io_obj->write_buffer[3]);
@@ -117,7 +125,7 @@ TEST_F(BufferTest, WriteVectorSimple)
         ASSERT_TRUE(bufset.empty());
 
         ASSERT_EQ(5, BufferTest::io_obj->write_buffer.size());
-        ASSERT_EQ(head.to_string(), BufferTest::io_obj->write_buffer[0]);
+        ASSERT_EQ(head->to_string(), BufferTest::io_obj->write_buffer[0]);
         ASSERT_EQ("QWEASDZXC+", BufferTest::io_obj->write_buffer[1]);
         ASSERT_EQ("RTYFGHVBN-", BufferTest::io_obj->write_buffer[2]);
         ASSERT_EQ("!@#$%^&", BufferTest::io_obj->write_buffer[3]);
@@ -130,16 +138,16 @@ TEST_F(BufferTest, WriteVectorSimple)
         BufferTest::io_obj->writing_sizes.push_back(20);
 
         BufferSet bufset;
-        bufset.append(util::mkref(head));
-        bufset.append(util::mkref(body));
-        bufset.append(util::mkref(tail));
+        bufset.append(head);
+        bufset.append(body);
+        bufset.append(tail);
 
         bool w = bufset.writev(0);
         ASSERT_FALSE(w);
         ASSERT_FALSE(bufset.empty());
 
         ASSERT_EQ(2, BufferTest::io_obj->write_buffer.size());
-        ASSERT_EQ(head.to_string(), BufferTest::io_obj->write_buffer[0]);
+        ASSERT_EQ(head->to_string(), BufferTest::io_obj->write_buffer[0]);
         ASSERT_EQ("QWEASDZXC+", BufferTest::io_obj->write_buffer[1]);
 
         w = bufset.writev(0);
@@ -147,7 +155,7 @@ TEST_F(BufferTest, WriteVectorSimple)
         ASSERT_FALSE(bufset.empty());
 
         ASSERT_EQ(4, BufferTest::io_obj->write_buffer.size());
-        ASSERT_EQ(head.to_string(), BufferTest::io_obj->write_buffer[0]);
+        ASSERT_EQ(head->to_string(), BufferTest::io_obj->write_buffer[0]);
         ASSERT_EQ("QWEASDZXC+", BufferTest::io_obj->write_buffer[1]);
         ASSERT_EQ("RTYFGHVBN-", BufferTest::io_obj->write_buffer[2]);
         ASSERT_EQ("!@#$%^&*()", BufferTest::io_obj->write_buffer[3]);
@@ -157,7 +165,7 @@ TEST_F(BufferTest, WriteVectorSimple)
         ASSERT_TRUE(bufset.empty());
 
         ASSERT_EQ(5, BufferTest::io_obj->write_buffer.size());
-        ASSERT_EQ(head.to_string(), BufferTest::io_obj->write_buffer[0]);
+        ASSERT_EQ(head->to_string(), BufferTest::io_obj->write_buffer[0]);
         ASSERT_EQ("QWEASDZXC+", BufferTest::io_obj->write_buffer[1]);
         ASSERT_EQ("RTYFGHVBN-", BufferTest::io_obj->write_buffer[2]);
         ASSERT_EQ("!@#$%^&*()", BufferTest::io_obj->write_buffer[3]);
@@ -170,16 +178,16 @@ TEST_F(BufferTest, WriteVectorSimple)
         BufferTest::io_obj->writing_sizes.push_back(23);
 
         BufferSet bufset;
-        bufset.append(util::mkref(head));
-        bufset.append(util::mkref(body));
-        bufset.append(util::mkref(tail));
+        bufset.append(head);
+        bufset.append(body);
+        bufset.append(tail);
 
         bool w = bufset.writev(0);
         ASSERT_FALSE(w);
         ASSERT_FALSE(bufset.empty());
 
         ASSERT_EQ(2, BufferTest::io_obj->write_buffer.size());
-        ASSERT_EQ(head.to_string(), BufferTest::io_obj->write_buffer[0]);
+        ASSERT_EQ(head->to_string(), BufferTest::io_obj->write_buffer[0]);
         ASSERT_EQ("QWEASDZXC+", BufferTest::io_obj->write_buffer[1]);
 
         w = bufset.writev(0);
@@ -187,7 +195,7 @@ TEST_F(BufferTest, WriteVectorSimple)
         ASSERT_FALSE(bufset.empty());
 
         ASSERT_EQ(4, BufferTest::io_obj->write_buffer.size());
-        ASSERT_EQ(head.to_string(), BufferTest::io_obj->write_buffer[0]);
+        ASSERT_EQ(head->to_string(), BufferTest::io_obj->write_buffer[0]);
         ASSERT_EQ("QWEASDZXC+", BufferTest::io_obj->write_buffer[1]);
         ASSERT_EQ("RTYFGHVBN-", BufferTest::io_obj->write_buffer[2]);
         ASSERT_EQ("!@#$%^&*()ABC", BufferTest::io_obj->write_buffer[3]);
@@ -197,7 +205,7 @@ TEST_F(BufferTest, WriteVectorSimple)
         ASSERT_TRUE(bufset.empty());
 
         ASSERT_EQ(5, BufferTest::io_obj->write_buffer.size());
-        ASSERT_EQ(head.to_string(), BufferTest::io_obj->write_buffer[0]);
+        ASSERT_EQ(head->to_string(), BufferTest::io_obj->write_buffer[0]);
         ASSERT_EQ("QWEASDZXC+", BufferTest::io_obj->write_buffer[1]);
         ASSERT_EQ("RTYFGHVBN-", BufferTest::io_obj->write_buffer[2]);
         ASSERT_EQ("!@#$%^&*()ABC", BufferTest::io_obj->write_buffer[3]);
@@ -205,10 +213,129 @@ TEST_F(BufferTest, WriteVectorSimple)
     }
 }
 
+TEST_F(BufferTest, PartiallyWrite)
+{
+    std::shared_ptr<Buffer> head(new Buffer("0123456789!@#$%^&*()"));
+    std::shared_ptr<Buffer> body(new Buffer("QWERTYUIOPqwertyuiop"));
+    std::shared_ptr<Buffer> tail(new Buffer("ABCDEFGHIJabcdefghij"));
+
+    // exactly 20 bytes
+
+    BufferTest::io_obj->writing_sizes.push_back(20);
+    BufferTest::io_obj->writing_sizes.push_back(-1);
+    BufferTest::io_obj->writing_sizes.push_back(20);
+    BufferTest::io_obj->writing_sizes.push_back(-1);
+    BufferTest::io_obj->writing_sizes.push_back(20);
+    BufferTest::io_obj->writing_sizes.push_back(-1);
+
+    BufferSet buf;
+    buf.append(head);
+    buf.append(body);
+    buf.append(tail);
+
+    bool w = buf.writev(0);
+    ASSERT_FALSE(w);
+    ASSERT_EQ(1, BufferTest::io_obj->write_buffer.size());
+    ASSERT_EQ(head->to_string(), BufferTest::io_obj->write_buffer[0]);
+    ASSERT_FALSE(buf.empty());
+    BufferTest::io_obj->write_buffer.clear();
+
+    w = buf.writev(0);
+    ASSERT_FALSE(w);
+    ASSERT_EQ(1, BufferTest::io_obj->write_buffer.size());
+    ASSERT_EQ(body->to_string(), BufferTest::io_obj->write_buffer[0]);
+    ASSERT_FALSE(buf.empty());
+    BufferTest::io_obj->write_buffer.clear();
+
+    w = buf.writev(0);
+    ASSERT_TRUE(w);
+    ASSERT_EQ(1, BufferTest::io_obj->write_buffer.size());
+    ASSERT_EQ(tail->to_string(), BufferTest::io_obj->write_buffer[0]);
+    ASSERT_TRUE(buf.empty());
+    BufferTest::io_obj->write_buffer.clear();
+    BufferTest::io_obj->writing_sizes.clear();
+
+    // 1 byte less
+
+    BufferTest::io_obj->writing_sizes.push_back(19);
+    BufferTest::io_obj->writing_sizes.push_back(19);
+    BufferTest::io_obj->writing_sizes.push_back(19);
+    BufferTest::io_obj->writing_sizes.push_back(19);
+
+    buf.append(head);
+    buf.append(body);
+    buf.append(tail);
+
+    w = buf.writev(0);
+    ASSERT_FALSE(w);
+    ASSERT_EQ(1, BufferTest::io_obj->write_buffer.size());
+    ASSERT_EQ("0123456789!@#$%^&*(", BufferTest::io_obj->write_buffer[0]);
+    ASSERT_FALSE(buf.empty());
+    BufferTest::io_obj->write_buffer.clear();
+
+    w = buf.writev(0);
+    ASSERT_FALSE(w);
+    ASSERT_EQ(2, BufferTest::io_obj->write_buffer.size());
+    ASSERT_EQ(")", BufferTest::io_obj->write_buffer[0]);
+    ASSERT_EQ("QWERTYUIOPqwertyui", BufferTest::io_obj->write_buffer[1]);
+    ASSERT_FALSE(buf.empty());
+    BufferTest::io_obj->write_buffer.clear();
+
+    w = buf.writev(0);
+    ASSERT_FALSE(w);
+    ASSERT_EQ(2, BufferTest::io_obj->write_buffer.size());
+    ASSERT_EQ("op", BufferTest::io_obj->write_buffer[0]);
+    ASSERT_EQ("ABCDEFGHIJabcdefg", BufferTest::io_obj->write_buffer[1]);
+    ASSERT_FALSE(buf.empty());
+    BufferTest::io_obj->write_buffer.clear();
+
+    w = buf.writev(0);
+    ASSERT_TRUE(w);
+    ASSERT_EQ(1, BufferTest::io_obj->write_buffer.size());
+    ASSERT_EQ("hij", BufferTest::io_obj->write_buffer[0]);
+    ASSERT_TRUE(buf.empty());
+    BufferTest::io_obj->write_buffer.clear();
+    BufferTest::io_obj->writing_sizes.clear();
+
+    // 1 byte more
+
+    BufferTest::io_obj->writing_sizes.push_back(21);
+    BufferTest::io_obj->writing_sizes.push_back(21);
+    BufferTest::io_obj->writing_sizes.push_back(21);
+
+    buf.append(head);
+    buf.append(body);
+    buf.append(tail);
+
+    w = buf.writev(0);
+    ASSERT_FALSE(w);
+    ASSERT_EQ(2, BufferTest::io_obj->write_buffer.size());
+    ASSERT_EQ("0123456789!@#$%^&*()", BufferTest::io_obj->write_buffer[0]);
+    ASSERT_EQ("Q", BufferTest::io_obj->write_buffer[1]);
+    ASSERT_FALSE(buf.empty());
+    BufferTest::io_obj->write_buffer.clear();
+
+    w = buf.writev(0);
+    ASSERT_FALSE(w);
+    ASSERT_EQ(2, BufferTest::io_obj->write_buffer.size());
+    ASSERT_EQ("WERTYUIOPqwertyuiop", BufferTest::io_obj->write_buffer[0]);
+    ASSERT_EQ("AB", BufferTest::io_obj->write_buffer[1]);
+    ASSERT_FALSE(buf.empty());
+    BufferTest::io_obj->write_buffer.clear();
+
+    w = buf.writev(0);
+    ASSERT_TRUE(w);
+    ASSERT_EQ(1, BufferTest::io_obj->write_buffer.size());
+    ASSERT_EQ("CDEFGHIJabcdefghij", BufferTest::io_obj->write_buffer[0]);
+    ASSERT_TRUE(buf.empty());
+    BufferTest::io_obj->write_buffer.clear();
+    BufferTest::io_obj->writing_sizes.clear();
+}
+
 TEST_F(BufferTest, WriteSinglePieceMultipleTimes)
 {
-    Buffer x(Buffer::from_string("0123456789abcdefghij"));
-    Buffer y(Buffer::from_string("QWEASDZXC+RTYFGHVBN-"));
+    std::shared_ptr<Buffer> x(new Buffer("0123456789abcdefghij"));
+    std::shared_ptr<Buffer> y(new Buffer("QWEASDZXC+RTYFGHVBN-"));
 
     BufferTest::io_obj->writing_sizes.push_back(1);
     BufferTest::io_obj->writing_sizes.push_back(2);
@@ -219,8 +346,8 @@ TEST_F(BufferTest, WriteSinglePieceMultipleTimes)
     BufferTest::io_obj->writing_sizes.push_back(2);
 
     BufferSet bufset;
-    bufset.append(util::mkref(x));
-    bufset.append(util::mkref(y));
+    bufset.append(x);
+    bufset.append(y);
 
     bool w = bufset.writev(0);
     ASSERT_FALSE(w);
@@ -289,27 +416,27 @@ TEST_F(BufferTest, WriteSinglePieceMultipleTimes)
 
 TEST_F(BufferTest, WriteVectorLargeBuffer)
 {
-    int const WRITEV_MAX_SIZE = 2 * 1024 * 1024;
-    int fill_x = WRITEV_MAX_SIZE * 3 / 4;
-    int fill_y = WRITEV_MAX_SIZE * 4 / 5;
-    int fill_z = WRITEV_MAX_SIZE * 4 / 3;
+    int const WRITEV_SIZE = 2 * 1024 * 1024;
+    int fill_x = WRITEV_SIZE * 3 / 4;
+    int fill_y = WRITEV_SIZE * 4 / 5;
+    int fill_z = WRITEV_SIZE * 4 / 3;
 
-    Buffer b(Buffer::from_string("begin"));
-    Buffer x(Buffer::from_string(std::string(fill_x, 'x')));
-    Buffer y(Buffer::from_string(std::string(fill_y, 'y')));
-    Buffer z(Buffer::from_string(std::string(fill_z, 'z')));
-    Buffer a(Buffer::from_string("abc"));
-    Buffer m(Buffer::from_string(std::string(WRITEV_MAX_SIZE, 'm')));
-    Buffer u(Buffer::from_string("uvw"));
+    std::shared_ptr<Buffer> b(new Buffer("begin"));
+    std::shared_ptr<Buffer> x(new Buffer(std::string(fill_x, 'x')));
+    std::shared_ptr<Buffer> y(new Buffer(std::string(fill_y, 'y')));
+    std::shared_ptr<Buffer> z(new Buffer(std::string(fill_z, 'z')));
+    std::shared_ptr<Buffer> a(new Buffer("abc"));
+    std::shared_ptr<Buffer> m(new Buffer(std::string(WRITEV_SIZE, 'm')));
+    std::shared_ptr<Buffer> u(new Buffer("uvw"));
 
     BufferSet bufset;
-    bufset.append(util::mkref(b));
-    bufset.append(util::mkref(x));
-    bufset.append(util::mkref(y));
-    bufset.append(util::mkref(z));
-    bufset.append(util::mkref(a));
-    bufset.append(util::mkref(m));
-    bufset.append(util::mkref(u));
+    bufset.append(b);
+    bufset.append(x);
+    bufset.append(y);
+    bufset.append(z);
+    bufset.append(a);
+    bufset.append(m);
+    bufset.append(u);
 
     bool w = bufset.writev(0);
     ASSERT_TRUE(w);
@@ -317,7 +444,7 @@ TEST_F(BufferTest, WriteVectorLargeBuffer)
 
     ASSERT_EQ(7, BufferTest::io_obj->write_buffer.size());
 
-    ASSERT_EQ(b.size(), BufferTest::io_obj->write_buffer[0].size());
+    ASSERT_EQ(b->size(), BufferTest::io_obj->write_buffer[0].size());
     ASSERT_EQ("begin", BufferTest::io_obj->write_buffer[0]);
 
     ASSERT_EQ(fill_x, BufferTest::io_obj->write_buffer[1].size());
@@ -326,37 +453,39 @@ TEST_F(BufferTest, WriteVectorLargeBuffer)
     }
 
     ASSERT_EQ(fill_y, BufferTest::io_obj->write_buffer[2].size());
-    for (unsigned i = b.size(); i < BufferTest::io_obj->write_buffer[2].size(); ++i) {
+    for (unsigned i = b->size(); i < BufferTest::io_obj->write_buffer[2].size(); ++i) {
         ASSERT_EQ('y', BufferTest::io_obj->write_buffer[2][i]) << " at " << i;
     }
 
     ASSERT_EQ(fill_z, BufferTest::io_obj->write_buffer[3].size());
-    for (unsigned i = b.size(); i < BufferTest::io_obj->write_buffer[3].size(); ++i) {
+    for (unsigned i = b->size(); i < BufferTest::io_obj->write_buffer[3].size(); ++i) {
         ASSERT_EQ('z', BufferTest::io_obj->write_buffer[3][i]) << " at " << i;
     }
 
-    ASSERT_EQ(a.size(), BufferTest::io_obj->write_buffer[4].size());
+    ASSERT_EQ(a->size(), BufferTest::io_obj->write_buffer[4].size());
     ASSERT_EQ("abc", BufferTest::io_obj->write_buffer[4]);
 
-    ASSERT_EQ(WRITEV_MAX_SIZE, BufferTest::io_obj->write_buffer[5].size());
-    for (unsigned i = b.size(); i < BufferTest::io_obj->write_buffer[5].size(); ++i) {
+    ASSERT_EQ(WRITEV_SIZE, BufferTest::io_obj->write_buffer[5].size());
+    for (unsigned i = b->size(); i < BufferTest::io_obj->write_buffer[5].size(); ++i) {
         ASSERT_EQ('m', BufferTest::io_obj->write_buffer[5][i]) << " at " << i;
     }
 
-    ASSERT_EQ(u.size(), BufferTest::io_obj->write_buffer[6].size());
+    ASSERT_EQ(u->size(), BufferTest::io_obj->write_buffer[6].size());
     ASSERT_EQ("uvw", BufferTest::io_obj->write_buffer[6]);
 }
 
 TEST_F(BufferTest, Write50KBuffers)
 {
-    int const SIZE = 500000;
-    std::vector<Buffer> storage;
+    ASSERT_EQ(10, (std::string("ab") * 5).size());
+    int const SIZE = 50000;
+    std::vector<std::shared_ptr<Buffer>> storage;
     BufferSet bufset;
     for (int i = 0; i < SIZE; ++i) {
-        storage.push_back(Buffer::from_string("VALUE:" + util::str(100000000LL + i) + '$'));
+        storage.push_back(std::shared_ptr<Buffer>(new Buffer(
+            ("VALUE:" + util::str(100000000LL + i) + '$') * 40)));
     }
     for (int i = 0; i < SIZE; ++i) {
-        bufset.append(util::mkref(storage[i]));
+        bufset.append(storage[i]);
     }
 
     bool w = bufset.writev(0);
@@ -364,7 +493,7 @@ TEST_F(BufferTest, Write50KBuffers)
 
     ASSERT_EQ(SIZE, BufferTest::io_obj->write_buffer.size());
     for (int i = 0; i < SIZE; ++i) {
-        ASSERT_EQ("VALUE:" + util::str(100000000LL + i) + '$',
+        ASSERT_EQ(("VALUE:" + util::str(100000000LL + i) + '$') * 40,
                   BufferTest::io_obj->write_buffer[i])
             << " at " << i;
     }

--- a/test/event-loop-test.hpp
+++ b/test/event-loop-test.hpp
@@ -35,6 +35,11 @@ struct MultipleBuffersIO
     {
         return ++this->last_fd;
     }
+
+    void push_writing_size(int fd, int sz)
+    {
+        buffers[fd].writing_sizes.push_back(sz);
+    }
 };
 
 struct AutomaticPoller

--- a/test/mock-io.cpp
+++ b/test/mock-io.cpp
@@ -32,6 +32,7 @@ ssize_t CIOImplement::writev(int fd, cio::iovec const* iov, int iovcnt)
 {
     ssize_t n = 0;
     for (int i = 0; i < iovcnt; ++i) {
+        EXPECT_LE(iov[i].iov_len, 0xFFFFFF);
         ssize_t s = this->write(fd, iov[i].iov_base, iov[i].iov_len);
         if (-1 == s) {
             return n ? n : -1;

--- a/test/response.cpp
+++ b/test/response.cpp
@@ -9,14 +9,14 @@ using cerb::split_server_response;
 TEST(Response, String)
 {
     {
-        Buffer b(Buffer::from_string("+OK\r\n"));
+        Buffer b("+OK\r\n");
         std::vector<util::sptr<Response>> r(split_server_response(b));
         ASSERT_TRUE(b.empty());
         ASSERT_EQ(1, r.size());
         ASSERT_EQ("+OK\r\n", r[0]->get_buffer().to_string());
     }
     {
-        Buffer b(Buffer::from_string("$2\r\nOK\r\n$4\r\nabcd\r\n"));
+        Buffer b("$2\r\nOK\r\n$4\r\nabcd\r\n");
         std::vector<util::sptr<Response>> r(split_server_response(b));
         ASSERT_TRUE(b.empty());
         ASSERT_EQ(2, r.size());
@@ -28,8 +28,7 @@ TEST(Response, String)
 TEST(Response, Array)
 {
     {
-        Buffer b(Buffer::from_string("+OK\r\n"
-                                     "*0\r\n"));
+        Buffer b("+OK\r\n" "*0\r\n");
         std::vector<util::sptr<Response>> r(split_server_response(b));
         ASSERT_TRUE(b.empty());
         ASSERT_EQ(2, r.size());
@@ -37,10 +36,10 @@ TEST(Response, Array)
         ASSERT_EQ("*0\r\n", r[1]->get_buffer().to_string());
     }
     {
-        Buffer b(Buffer::from_string("+OK\r\n"
-                                     "*2\r\n"
-                                         "$1\r\na\r\n"
-                                         "$1\r\nb\r\n"));
+        Buffer b("+OK\r\n"
+                 "*2\r\n"
+                     "$1\r\na\r\n"
+                     "$1\r\nb\r\n");
         std::vector<util::sptr<Response>> r(split_server_response(b));
         ASSERT_TRUE(b.empty());
         ASSERT_EQ(2, r.size());

--- a/test/script_test.py
+++ b/test/script_test.py
@@ -53,5 +53,15 @@ class ScriptTest(unittest.TestCase):
             self.assertEqual([c + b for b in p], self.t.talk_bulk(
                 [['get', '.' + b + c] for b in p]))
 
+    def test_large_pipes(self):
+        r = self.t.talk_bulk([['set', 'Key:%016d' % i, 'Value:%026d' % i]
+                              for i in xrange(1000)])
+        self.assertEqual(['OK'] * 1000, r)
+        r = self.t.talk_bulk([['gEt', 'Key:%016d' % i] for i in xrange(2000)])
+        self.assertEqual(2000, len(r))
+        self.assertEqual(['Value:%026d' % i for i in xrange(1000)], r[:1000])
+        self.assertEqual([None] * 1000, r[1000:])
+
+
 if __name__ == '__main__':
     main()

--- a/test/server-client.cpp
+++ b/test/server-client.cpp
@@ -315,7 +315,7 @@ TEST_F(ServerClientTest, PipeRemoteCommands)
     ASSERT_RO_CONN(client);
     ASSERT_RO_CONN(server);
 
-    ServerClientTest::io_obj->read_buffer.push_back("yuko\r\n");
+    ServerClientTest::io_obj->read_buffer.push_back("aioi\r\n");
     server->on_events(ManualPoller::EV_READ);
     ServerClientTest::set_polls();
     ASSERT_RW_CONN(client);
@@ -330,7 +330,7 @@ TEST_F(ServerClientTest, PipeRemoteCommands)
     ASSERT_EQ("$10\r\nnaganohara\r\n", ServerClientTest::io_obj->write_buffer[1]);
     ASSERT_EQ("*2\r\n$3\r\n", ServerClientTest::io_obj->write_buffer[2]);
     ASSERT_EQ("GET\r\n$4\r\nyuko\r\n", ServerClientTest::io_obj->write_buffer[3]);
-    ASSERT_EQ("$4\r\nyuko\r\n", ServerClientTest::io_obj->write_buffer[4]);
+    ASSERT_EQ("$4\r\naioi\r\n", ServerClientTest::io_obj->write_buffer[4]);
 }
 
 TEST_F(ServerClientTest, MultipleClientsPipelineTest)
@@ -447,7 +447,7 @@ TEST_F(ServerClientTest, MultipleClientsPipelineTest)
     for (int i = PIPE_Y; i < PIPE_Z; ++i) {
         ASSERT_EQ(requests_z[i], ServerClientTest::io_obj->write_buffer[i - PIPE_Y]);
     }
-    ASSERT_RW_CONN(server);
+    ASSERT_RO_CONN(server);
     ServerClientTest::io_obj->write_buffer.clear();
 
     for (int i = 0; i < PIPE_Y; ++i) {
@@ -472,11 +472,6 @@ TEST_F(ServerClientTest, MultipleClientsPipelineTest)
     }
     ServerClientTest::io_obj->write_buffer.clear();
 
-    server->on_events(ManualPoller::EV_WRITE);
-    ServerClientTest::set_polls();
-    ASSERT_RW_CONN(server);
-    ASSERT_EQ(0, ServerClientTest::io_obj->write_buffer.size());
-
     std::vector<std::string> rsp_y_to_z(responses_z.begin() + PIPE_Y, responses_z.end());
     ServerClientTest::io_obj->read_buffer.push_back(util::join("", rsp_y_to_z));
 
@@ -489,7 +484,7 @@ TEST_F(ServerClientTest, MultipleClientsPipelineTest)
     for (int i = PIPE_Y; i < PIPE_Z; ++i) {
         ASSERT_RW_CONN(clients[i]);
     }
-    ASSERT_RW_CONN(server);
+    ASSERT_RO_CONN(server);
     ASSERT_EQ(PIPE_Y, ServerClientTest::io_obj->write_buffer.size());
     for (int i = 0; i < PIPE_Y; ++i) {
         ASSERT_EQ(requests_z[i], ServerClientTest::io_obj->write_buffer[i]);

--- a/test/test-utils.hpp
+++ b/test/test-utils.hpp
@@ -1,0 +1,13 @@
+#ifndef __CERBERUS_TEST_UTILIIES_HPP__
+#define __CERBERUS_TEST_UTILIIES_HPP__
+
+static std::string operator*(std::string const& s, int times)
+{
+    std::string r;
+    while (times --> 0) {
+        r += s;
+    }
+    return std::move(r);
+}
+
+#endif /* __CERBERUS_TEST_UTILIIES_HPP__ */


### PR DESCRIPTION
#13 将缓冲区设为 `std::shared_ptr` 令客户端在释放时不会造成未写完的 `Server::_output_buffer_set` 中的引用失效.

另外限制客户端一次 pipe 的数量 (到 64, 对于普通应用来说, 与之前无异), 超过此 pipe 之后, 多出的部分会先缓存起来, 因为客户端需要等待一组请求全部完成时才会写回, 这一调整加快了大 pipeline 返回指令的速度.