### PR TITLE
fix segment fault when pop_cient

### DIFF
--- a/core/server.cpp
+++ b/core/server.cpp
@@ -101,7 +101,10 @@ void Server::pop_client(Client* cli)
             return cmd->group->client.is(cli);
         });
     for (util::sref<DataCommand>& cmd: this->_sent_commands) {
-        if (cmd.not_nul() && cmd->group->client.is(cli)) {
+        if (cmd.not_nul() &&
+            cmd->group.not_nul() &&
+            cmd->group->client.not_nul() &&
+            cmd->group->client.is(cli)) {
             cmd.reset();
         }
     }


### PR DESCRIPTION
Change-Id: Iac69a825156c7957273e464055a7faacf88a5540

这个能解决部分的segment fault，当cmd->group，cmd->group->client结构体里面的ptr是nul的时候，但cmd->group->client为Null的时候还有可能会segmentfault.