### PR TITLE
multi startup nodes support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Run
 The first argument is path of a configuration file, then optional arguments. Those specifies
 
 * bind / `-b` : (integer) local port to listen; could also specified
-* node / `-n` : (address, optional) one of active node in a cluster; format should be *host:port*; could also set after cerberus launched, via the `SETREMOTES` command, see it below
+* node / `-n` : (address) active nodes in a cluster; format should be *host1:port1,host2:port2*; could also set after cerberus launched, via the `SETREMOTES` command, see it below
 * thread / `-t` : (integer) number of threads
 * read-slave / `-r` : (optional, default off) set to "yes" to turn on read slave mode. A proxy in read-slave mode won't support writing commands like `SET`, `INCR`, `PUBLISH`, and it would select slave nodes for reading commands if possible. For more information please read [here (CN)](https://github.com/HunanTV/redis-cerberus/wiki/%E8%AF%BB%E5%86%99%E5%88%86%E7%A6%BB).
 * read-slave-filter / `-R` : (optional, need read-slave set to "yes") if multiple slaves replicating one master, use the one whose host starts with this option value; for example, you have `10.0.0.1:7000` as a master, with 2 slave `10.0.1.1:8000` and `10.0.2.1:9000`, and read-slave-filter set to `10.0.1`, then `10.0.1.1:8000` is preferred. Note this option is no more than a string matching, so `10.0.1.1` and `10.0.10.1` won't be different on option value `10.0.1`

--- a/common.hpp
+++ b/common.hpp
@@ -3,7 +3,7 @@
 
 #include <chrono>
 
-#define VERSION "0.7.9-2016-08-18"
+#define VERSION "0.7.10-2017-02-28"
 
 namespace cerb {
 

--- a/example.conf
+++ b/example.conf
@@ -1,5 +1,5 @@
 bind 8889
-node 127.0.0.1:7000
+node 127.0.0.1:7000,127.0.0.2:7001
 thread 4
 read-slave no
 read-slave-filter 10.0.1

--- a/main.cpp
+++ b/main.cpp
@@ -132,7 +132,7 @@ namespace {
         }
 
         if (config.contains("node")) {
-            cerb_global::set_remotes({util::Address::from_host_port(config.get("node"))});
+            cerb_global::set_remotes(util::Address::from_hosts_ports(config.get("node")));
         } else {
             LOG(WARNING) << "Remote is not set in config file; to set it by command,"
                             " use `SETREMOTES <host> <port>' in a redis-cli prompt";

--- a/utils/address.cpp
+++ b/utils/address.cpp
@@ -14,6 +14,21 @@ Address Address::from_host_port(std::string const& addr)
     return Address(host_port[0], util::atoi(host_port[1].data()));
 }
 
+std::set<util::Address> Address::from_hosts_ports(std::string const& addrs)
+{
+    std::set<util::Address> res;
+    std::vector<std::string> hosts_ports(split_str(addrs, ","));
+    for (auto &s: hosts_ports) {
+        if (s.size() > 0) {
+            res.insert(from_host_port(s));
+        }
+    }
+    if (res.size() == 0) {
+        throw std::runtime_error("remote address is empty.");
+    }
+    return res;
+}
+
 std::string Address::str() const
 {
     return this->host + ':' + util::str(this->port);

--- a/utils/address.hpp
+++ b/utils/address.hpp
@@ -2,6 +2,7 @@
 #define __CERBERUS_UTILITY_ADDRESS_HPP__
 
 #include <string>
+#include <set>
 
 namespace util {
 
@@ -25,6 +26,7 @@ namespace util {
         {}
 
         static Address from_host_port(std::string const& addr);
+        static std::set<util::Address> from_hosts_ports(std::string const& addrs);
 
         Address& operator=(Address const& rhs)
         {


### PR DESCRIPTION
1.当启动节点只有一个的时候，这个节点可能会挂掉导致代理也可能出现问题，导致client端访问redis集群受影响。
2.集群一般情况下是由多个节点组成的，所以启动节点配置成多个也是比较正常的。