### PR TITLE
support docker deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 cerberus
+*.swp
 *.o
 tmp.*
 dump.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu
+
+COPY cerberus /usr/local/bin/
+COPY example.conf /etc/cerberus.conf
+COPY docker-entrypoint.sh /usr/local/bin/
+
+EXPOSE 8889
+
+CMD ["docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ The option set via ARGS would override it in the configuration file. For example
 
 set the program to 8 threads.
 
+Docker support
+===
+After being compiled, start a simple setup including connecting a local redis cluster like this:
+
+> docker-compose up -d
+
+Then you can connect the proxy with redis-cli or other redis client tools.
+
 Commands in Particular
 ===
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3'
+services:
+    redis-cluster:
+        image: "grokzen/redis-cluster"
+
+    cerberus:
+        build: .
+        container_name: cerberus
+        ports:
+            - "8889:8889"
+        depends_on:
+            - redis-cluster
+        environment:
+            REDIS_CLUSTER_NODES: redis-cluster:7000

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+cerberus /etc/cerberus.conf -n ${REDIS_CLUSTER_NODES}


### PR DESCRIPTION
To make use of DNS functionality provided by docker, resolving hostname
to IP is necessary, so change `connect_fd` a little to satisfy it.

Signed-off-by: cshi <baiwfg2@gmail.com>